### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Vial implements several additional quality-of-life features that are documented 
 
 ## Documentation topics
 
-* [Porting a keyboard to VIA](doc/porting-via.md)
-* [Porting a VIA keyboard to Vial](doc/porting-vial.md)
-* [Implementing Vial encoder support](doc/encoders.md)
-* [Vial security features and options](doc/security.md)
+* [Porting a keyboard to VIA](https://vial-kb.github.io/gettingStarted/porting-to-via.html)
+* [Porting a VIA keyboard to Vial](https://vial-kb.github.io/gettingStarted/porting-to-vial.html)
+* [Implementing Vial encoder support](https://vial-kb.github.io/gettingStarted/encoders.html)
+* [Vial security features and options](https://vial-kb.github.io/security.html)


### PR DESCRIPTION
Change links to point to vial-kb.github.io documentation

Let me know if this isn't what was planned.