### PR TITLE
Fix links to docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ Beta version
 {: .mt-1 .mb-8 .text-grey-dk-100 .line-height-fix }
 
 [Download Vial](/download){: .btn .gettingStarted .blue}
-[Build support for your keyboard](/gettingStarted/porting-to-via.md){: .btn .gettingStarted}
+[Build support for your keyboard](/gettingStarted/porting-to-via){: .btn .gettingStarted}
 [Join our Discord server](https://discord.gg/6Ybrtvj6Ae){: .btn .gettingStarted}
 
 
@@ -28,14 +28,14 @@ Another big goal for this project is to reduce reliance on third parties when de
 
 With Vial, you do not have to submit your keyboard as a pull-request for QMK and/or VIA before it can be used in the GUI; rather, the keymap JSON definition is stored within the keyboard firmware and is retrieved at runtime.
 
-Vial implements several additional quality-of-life features that are documented in the topics linked below including support for [rotary encoders](gettingStarted/encoders.md).
+Vial implements several additional quality-of-life features that are documented in the topics linked below including support for [rotary encoders](gettingStarted/encoders).
 
 ![](img/vial-win-1.png)
 
 
 ## Documentation topics
 
-* [Porting a keyboard to VIA](/gettingStarted/porting-to-via.md)
-* [Porting a VIA keyboard to Vial](/gettingStarted/porting-to-vial.md)
-* [Implementing Vial encoder support](gettingStarted/encoders.md)
+* [Porting a keyboard to VIA](/gettingStarted/porting-to-via)
+* [Porting a VIA keyboard to Vial](/gettingStarted/porting-to-vial)
+* [Implementing Vial encoder support](gettingStarted/encoders)
 * [Vial security features and options](/security)


### PR DESCRIPTION
The links to documentation pages on the index page were giving 404 due to `.md` postfixes. Fix tested locally.