### PR TITLE
links to firmware size in manuals page

### DIFF
--- a/docs/manual/combos.md
+++ b/docs/manual/combos.md
@@ -10,7 +10,7 @@ nav_order: 5
 Combos allow you to add custom actions when a certain combination of keys is pressed. for example, hitting `A` and `S` within the combo term would hit `ESC` instead, or have it perform even more complex tasks.
 
 ## 1. Combos
-Click the **Combos** tab at the top and one of the available numbers below it. By default, 8 combos can be configured but that number could be smaller to reduce firmware size.
+Click the **Combos** tab at the top and one of the available numbers below it. By default, 8 combos can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
 ![](../img/combos-tab.png)
 

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -6,7 +6,9 @@ nav_order: 2
 ---
 
 # Layers
-Layers allow the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Most Vial devices have 4 layers but the firmware can be compiled to have less. Keys can be configured to switch between layers as needed similar to function keys on a laptop.
+Layers allow the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Keys can be configured to switch between layers as needed similar to function keys on a laptop. 
+
+Most Vial devices have 4 layers but this number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
 You can view each layer available by clicking the coresponding number at the top of the interface. You can see we already have layer 0 selected.
 

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -9,9 +9,9 @@ nav_order: 3
 
 Macros can be used to perform a pre-programmed sequence of actions or steps. 
 
-By default, 16 macros can be configured. This number can be lower as some firmwares do not have enough space for this many macros. 
+By default, 16 macros can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
-Some great example uses for macros could be typing out and address, opening a program with a hotkey-shortcut or filling out a form.
+Some great example uses for macros could be typing out an address, opening a program with a hotkey-shortcut or filling out a form.
 
 ## 1. Configure Macros
 Click the **Macros** tab. All the macros that can be configured will be displayed as seperate tabs. Select a Macro you would like to configure. In the picture below **M0** is selected
@@ -46,14 +46,6 @@ When you are satisfied with the configuration of all macros, click **save** to s
 After the macro has been configured, it can be used. Just click on a key you would like to use for a macro in the top palette then select your macro in the bottom palette. (under the macro tab)
 
 ![](../img/macro-overview.png)
-
-## 3. Changing the amount of Macros
-
-To increase or decrease the amount of macros you need to define it in your `keymaps/vial/config.h`, where 'xx' is the amount macros you want.
-```
-#define DYNAMIC_KEYMAP_MACRO_COUNT xx
-```
-Up to 109 is possible, the amount of macros will not change how much space is reserved for macros but every every blank entry will consume one byte in your EEPROM.
 
 # More info
 Macros is a QMK feature and more detailed information can be found with the [offical QMK documenation](https://docs.qmk.fm/#/feature_macros).

--- a/docs/manual/tap-dance.md
+++ b/docs/manual/tap-dance.md
@@ -10,7 +10,7 @@ nav_order: 4
 Tap Dance allows you to configure different actions depending on how a button is used. For example, the same button could be configured to active a macro when the button is tapped or activate something else when the button is held.
 
 ## 1. Configuring Tap Dance
-Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap Dance configurations can be used  but this number could be smaller to help reduce firmware size.
+Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap dances can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
 ![](../img/tap-tabs.png)
 


### PR DESCRIPTION
Edited manual files to point consistently point to the firmware size/features page for changing available number of slots