### PR TITLE
Reorder manual pages

### DIFF
--- a/docs/manual/linux-udev.md
+++ b/docs/manual/linux-udev.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuring udev on Linux
 parent: User manual
-nav_order: 6
+nav_order: 8
 has_toc: true
 redirect_from:
   - /getting-started/linux-udev.html

--- a/docs/manual/mod-tap-tapdance.md
+++ b/docs/manual/mod-tap-tapdance.md
@@ -2,7 +2,7 @@
 layout: default
 title: Mod Tap or Quantum vs Tap Dance
 parent: User manual
-nav_order: 8
+nav_order: 7
 ---
 
 # Tap Dance is a very powerful tool

--- a/docs/manual/qmk-settings.md
+++ b/docs/manual/qmk-settings.md
@@ -2,7 +2,7 @@
 layout: default
 title: QMK Settings
 parent: User manual
-nav_order: 7
+nav_order: 6
 ---
 
 # QMK Settings


### PR DESCRIPTION
Linux udev rules should probably be last, as that is more of a as-needed option, and the other options belong together,