### PR TITLE
fix: formatting of custom keycodes code example

### DIFF
--- a/docs/docs/custom_keycode.md
+++ b/docs/docs/custom_keycode.md
@@ -21,8 +21,8 @@ enum blender_keycode {
 }
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
-	switch (keycode) {
-		case B_VPAN:
+    switch (keycode) {
+        case B_VPAN:
             if (record->event.pressed) { ... }
             return 0;
         case B_DOLLY:
@@ -31,7 +31,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case B_UNDO:
             if (record->event.pressed) { ... }
             return 0;
-	}
+    }
 }
 ```
 

--- a/docs/docs/custom_keycode.md
+++ b/docs/docs/custom_keycode.md
@@ -18,7 +18,7 @@ enum blender_keycode {
     B_VPAN = SAFE_RANGE,
     B_DOLLY,
     B_UNDO,
-}
+};
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     switch (keycode) {
@@ -78,7 +78,7 @@ enum blender_keycode {
     B_VPAN = QK_KB_0,
     B_DOLLY,
     B_UNDO,
-}
+};
 ```
 
 Custom keycodes in the json file __must__ match what's inside the enum block, both in order and number of keycodes.


### PR DESCRIPTION
Using spaces for indent consistently (instead of tabs for some lines)

https://get.vial.today/docs/custom_keycode.html

<img width="452" height="335" alt="grafik" src="https://github.com/user-attachments/assets/83f9ffdf-55bc-44a9-9ee1-b37e205744a6" />
