### PR TITLE
Fix various misspellings and minor nits throughout the site.

### DIFF
--- a/docs/docs/custom_keycode.md
+++ b/docs/docs/custom_keycode.md
@@ -9,7 +9,7 @@ redirect_from:
 
 ## Custom keycodes in QMK
 
-QMK provides [a way](https://github.com/qmk/qmk_firmware/blob/master/docs/custom_quantum_functions.md) for user to redefine behavior for existing key or create new keycode.
+QMK provides [a way](https://github.com/qmk/qmk_firmware/blob/master/docs/custom_quantum_functions.md) for users to redefine behavior for existing keys or create new keycodes.
 
 For example, here 3 custom keycodes are defined within `keymap.c`. An `enum` block is used to assign each keycode a unique integer code, and then the behavior of each keycode is defined inside `process_record_user()`. The keycodes are then assigned inside the keymap as usual.
 
@@ -18,7 +18,7 @@ enum blender_keycode {
     B_VPAN = SAFE_RANGE,
     B_DOLLY,
     B_UNDO,
-}
+};
 
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 	switch (keycode) {
@@ -78,7 +78,7 @@ enum blender_keycode {
     B_VPAN = QK_KB_0,
     B_DOLLY,
     B_UNDO,
-}
+};
 ```
 
 Custom keycodes in the json file __must__ match what's inside the enum block, both in order and number of keycodes.

--- a/docs/docs/encoders.md
+++ b/docs/docs/encoders.md
@@ -83,7 +83,7 @@ Refer to [QMK documentation](https://docs.qmk.fm/#/feature_encoders?id=encoder-m
 
 ### Notable differences in Vial from QMK
 - In Vial, the layers are denoted by numbers only and cannot be named. If you are working from an existing QMK keymap, these need to be changed to reflect this. 
-- Encoder mapping ***replaces*** the older QMK style with encoder callbacks, which needs to be removed from the Vial `keymap.c` for your firmware to compile and work properly. They should, however, be left intact in the default keymap for backwards compatability with QMK.
+- Encoder mapping ***replaces*** the older QMK style with encoder callbacks, which needs to be removed from the Vial `keymap.c` for your firmware to compile and work properly. They should, however, be left intact in the default keymap for backwards compatibility with QMK.
 
 ### WARNING! 
 Do ***NOT*** edit the number '2' in this line:
@@ -94,7 +94,7 @@ It has ***nothing*** to do with the number of encoders, but denotes the two acti
 
 ## 3. Add Vial encoders as part of KLE keymap
 
-In the Vial JSON, an encoder is defined as either ***two or three*** 1u switches, with the labels representing the possible actions it can have (Clockwise/Counter Clockwise rotation). These lables are completely unique to the encoders, and are ***NOT*** part of the matrix.
+In the Vial JSON, an encoder is defined as either ***two or three*** 1u switches, with the labels representing the possible actions it can have (Clockwise/Counter Clockwise rotation). These labels are completely unique to the encoders, and are ***NOT*** part of the matrix.
 
 **Not having both rotary switches defined makes the JSON invalid.**
 

--- a/docs/docs/firmware-size.md
+++ b/docs/docs/firmware-size.md
@@ -23,11 +23,11 @@ make: *** [Makefile:530: yd60mq:vial] Error 1
 Make finished with errors
 ```
 
-If that happens to your keyboard, you can try utilizing of the options below to make the firmware fit. Depending on the type of keyboard (full-size/split/macropad etc), some options simply aren't useful, and others may be entirely neccesary for it to function as intended.
+If that happens to your keyboard, you can try utilizing of the options below to make the firmware fit. Depending on the type of keyboard (full-size/split/macropad etc), some options simply aren't useful, and others may be entirely necessary for it to function as intended.
 
 This also means that some older designs with less powerful MCU's like the classic AVR line in the popular Pro Micro controllers, may need to disable features or reduce the amount of slots configured in some features to make the firmware fit into compiled memory and not run out of EEPROM or RAM.
 
-Besides compiled size, all features share the available EEPROM, and if you desire more than the standard amount of slots for one, you may need to disable one feature entirely or reduce the alloted memory to it for balance.
+Besides compiled size, all features share the available EEPROM, and if you desire more than the standard amount of slots for one, you may need to disable one feature entirely or reduce the allotted memory to it for balance.
 
 ## QMK Settings
 
@@ -47,7 +47,7 @@ Tap Dance is the GUI equivalent to [QMK's Tap Dance](https://docs.qmk.fm/#/featu
 
 ### Configure memory usage
 
-By default, the number of available Tap Dances are calculated from the amount of EEPROM your controller have. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+By default, the number of available Tap Dances is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`
 
 ```
 #define VIAL_TAP_DANCE_ENTRIES x
@@ -67,7 +67,7 @@ Combos are the GUI equivalent to [QMK's Combos](https://docs.qmk.fm/#/feature_co
 
 ### Configure memory usage
 
-By default, the number of available Combos are calculated from the amount of EEPROM your controller have. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+By default, the number of available Combos is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
 ```
 #define VIAL_COMBO_ENTRIES x
@@ -89,7 +89,7 @@ Don’t want shift + 1 to type ! on your computer? Use a key override to make yo
 
 ### Configure memory usage
 
-By default, the number of available Key Overrides are calculated from the amount of EEPROM your controller have. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+By default, the number of available Key Overrides is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
 ```
 #define VIAL_KEY_OVERRIDE_ENTRIES x
@@ -111,7 +111,7 @@ For example, after pressing `Ctrl + Shift + →` to select the next word, the Al
 
 ### Configure memory usage
 
-By default, the number of available Alt Repeat keys are calculated from the amount of EEPROM your controller have. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+By default, the number of available Alt Repeat keys is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
 ```
 #define VIAL_ALT_REPEAT_KEY_ENTRIES x
@@ -145,19 +145,19 @@ LTO makes the compiler work harder when optimizing your code, resulting in a sma
 
 > Information
 > {: .label .label-green }
-> Using LTO can in rare situations expose buggy code in a way which could break certain firmware functionality. Make sure to test your keyboard firmware throughly after enabling this option.
+> Using LTO can in rare situations expose buggy code in a way which could break certain firmware functionality. Make sure to test your keyboard firmware thoroughly after enabling this option.
 
 ## Using a different bootloader
 
 **If you have already done all of the above, and you still see this message trying to compile your firmware on an AVR such as the popular Atmega32u4 (used on Pro Micro), it might be time to break out of the mould a little.**
 
-Almost all of these controllers are delivered with the Caterina bootloader, and while this bootloader is very stable and plain **just works!** in all situtations, it's also fairly old code and quite large, using ~3500 bytes of your codespace. Most of it for features you will never really use.
+Almost all of these controllers are delivered with the Caterina bootloader, and while this bootloader is very stable and plain **just works!** in all situations, it's also fairly old code and quite large, using ~3500 bytes of your codespace. Most of it for features you will never really use.
 
 Changing your bootloader to a more modern, more slim-lined one that does exactly what is needed and nothing else, can save you a whole lot of codespace for your keymap and functions.
 
 ### Potential drawbacks
 
-**Changing the bootloader makes your firmware somewhat 'non-standard'**, so sharing them means the other user also have to swap to your preffered bootloader. It also requires you to use an ISP programmer (or another arduino) to flash the controller with the bootloader once, before it can be used as normal flashing the code over USB. (This is very similar to recovering the bootloader in the event of a bricked Pro Micro).
+**Changing the bootloader makes your firmware somewhat 'non-standard'**, so sharing them means the other user also has to swap to your preferred bootloader. It also requires you to use an ISP programmer (or another Arduino) to flash the controller with the bootloader once, before it can be used as normal flashing the code over USB. (This is very similar to recovering the bootloader in the event of a bricked Pro Micro).
 
 ### What bootloader is recommended?
 

--- a/docs/docs/porting-to-via.md
+++ b/docs/docs/porting-to-via.md
@@ -37,7 +37,7 @@ However as VIA have added more and more functionality in newer versions, and tha
 
 ### Create a physical layout
 
-Keyboard definition layouts are based on KLE data with additional information encoded within keys' legends. Go to [http://www.keyboard-layout-editor.com/](http://www.keyboard-layout-editor.com/) and create a layout that physically represents your keyboard. Use the "Tools -> Remove Legends" action in order to clean up any existing legends:
+Keyboard definition layouts are based on KLE data with additional information encoded within keys' legends. Go to [http://www.keyboard-layout-editor.com/](http://www.keyboard-layout-editor.com/) and create a layout that physically represents your keyboard. Use the "Tools &rarr; Remove Legends" action in order to clean up any existing legends:
 
 ![](../img/kle-empty.png)
 

--- a/docs/docs/porting-to-via.md
+++ b/docs/docs/porting-to-via.md
@@ -213,9 +213,9 @@ See [here](https://github.com/vial-kb/vial-qmk/blob/12950db4d8ec1f294b1285e9b554
 
 Before compiling a firmware using your newly created `vial.json` file, it is highly encouraged to test that the file displays and behaves as expected first, since a *technically correct* file with a complete but perhaps _visually incorrect_ layout will not be handled by the compiler.
 
-**To do this open up the Vial application and click `File` -> `Load dummy JSON` and select your file.**
+**To do this open up the Vial application and click `File` &rarr; `Load dummy JSON` and select your file.**
 
-A representation of your keyboard should now be shown on the screen, with the correct keys, in a resonably similar layout to as it was displayed in [http://www.keyboard-layout-editor.com/](http://www.keyboard-layout-editor.com/) or in real life. 
+A representation of your keyboard should now be shown on the screen, with the correct keys, in a reasonably similar layout to as it was displayed in [http://www.keyboard-layout-editor.com/](http://www.keyboard-layout-editor.com/) or in real life. 
 
 All layout options should be present and selectable as well as encoders shown as two round buttons with arrows (CW/CCW) and a normal button representing the click. 
 

--- a/docs/docs/porting-to-vial.md
+++ b/docs/docs/porting-to-vial.md
@@ -25,7 +25,7 @@ The second part of this tutorial will guide you through porting your keyboard to
 
 > Information
 > {: .label .label-green }
-> Compiling Vial firmwware requires some basic knowledge of how to use a command line environment—a bit more than just `qmk compile`. If you are unfamiliar with commands such as `cd` and `pwd`, please read through [this basic primer](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line#basic_built-in_terminal_commands) to learn the commands you'll need to know.
+> Compiling Vial firmware requires some basic knowledge of how to use a command line environment—a bit more than just `qmk compile`. If you are unfamiliar with commands such as `cd` and `pwd`, please read through [this basic primer](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line#basic_built-in_terminal_commands) to learn the commands you'll need to know.
 
 ## 1. Prepare Your Build Environment
 

--- a/docs/docs/porting-to-vial.md
+++ b/docs/docs/porting-to-vial.md
@@ -134,7 +134,7 @@ For keyboards that do not define `VIAL_INSECURE`, proceed to configure `VIAL_UNL
 * Note that this feature works with multi-layout keyboards, however you should make sure that the keys you pick appear in every possible layout:
 ![](../img/security-user-prompt.png)
 
-After you flash the firmware, check that the function works correctly by activating the "Security->Unlock" menu.
+After you flash the firmware, check that the function works correctly by activating the "Security&rarr;Unlock" menu.
 
 ## 7. Compile Vial firmware for your keyboard
 

--- a/docs/manual/alt-repeat-key.md
+++ b/docs/manual/alt-repeat-key.md
@@ -87,5 +87,5 @@ Rule 2:
 In the second rule, the last key has no effect and can be set to anything.
 
 
-# More info
-Alt Repeat Key is a QMK feature and more detailed information can be found with the [offical QMK documenation](https://docs.qmk.fm/features/repeat_key).
+## More info
+Alt Repeat Key is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/features/repeat_key).

--- a/docs/manual/combos.md
+++ b/docs/manual/combos.md
@@ -21,5 +21,5 @@ The settings for that particular combo will be shown. Up to 4 combination of key
 ## 2. Using a Combo
 After the combo has been configured and saved, it can be used. There is no need to assign it to a specific key. 
 
-# More info
-Combos is a QMK feature and more detailed information can be found with the [offical QMK documenation](https://docs.qmk.fm/#/feature_combo?id=combos).
+## More info
+Combos is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/#/feature_combo?id=combos).

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -6,7 +6,7 @@ nav_order: 2
 ---
 
 # Layers
-Layers allow the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Keys can be configured to switch between layers as needed similar to function keys on a laptop. 
+Layers provide the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Keys can be configured to switch between layers as needed similar to function keys on a laptop. 
 
 Most Vial devices have 4 layers but this number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
@@ -24,7 +24,7 @@ A typical layer setup would include a "base" layer and a "Function" layer.
 
 You can see additional key functionality is located on the "Function" layer. This is just convention, in reality you can do whatever you want with the layers.
 
-# Moving Between Layers
+## Moving Between Layers
 Switching between what layer is active can be done in a few ways. In the lower palette, select the **layer** tab to view all the different options. 
 
 - MO(layer)  - momentarily activates the layer. As soon as you let go of the key, the layer is deactivated.

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -14,7 +14,7 @@ By default, 16 macros can be configured. This number can be adjusted in firmware
 Some great example uses for macros could be typing out an address, opening a program with a hotkey-shortcut or filling out a form.
 
 ## 1. Configure Macros
-Click the **Macros** tab. All the macros that can be configured will be displayed as seperate tabs. Select a Macro you would like to configure. In the picture below **M0** is selected
+Click the **Macros** tab. All the macros that can be configured will be displayed as separate tabs. Select a Macro you would like to configure. In the picture below **M0** is selected
 
 ![](../img/macros-header1.png)
 
@@ -23,7 +23,7 @@ The next step is to add actions. In the bottom right corner, you can
 * **Tap Enter** - Lots of macros end with an "Enter" key so this button makes it easier to add that.
 * **Record macro** - Lets you record the macro directly from your keyboard. It's not the most reliable but it's a great place to start.
 
-Use these buttons to add actions to the list. These will be perfomed in order when the macro is activated.
+Use these buttons to add actions to the list. These will be performed in order when the macro is activated.
 
 Actions can be reordered using the arrows on the left. 
 
@@ -47,5 +47,5 @@ After the macro has been configured, it can be used. Just click on a key you wou
 
 ![](../img/macro-overview.png)
 
-# More info
-Macros is a QMK feature and more detailed information can be found with the [offical QMK documenation](https://docs.qmk.fm/#/feature_macros).
+## More info
+Macros is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/#/feature_macros).

--- a/docs/manual/tap-dance.md
+++ b/docs/manual/tap-dance.md
@@ -27,5 +27,5 @@ After the tap dance has been configured and saved, it can be used. Just click on
 
 ![](../img/tap-left-menu-example.png)
 
-# More info
-Tap Dance is a QMK feature and more detailed information can be found with the [offical QMK documenation](https://docs.qmk.fm/#/feature_tap_dance).
+## More info
+Tap Dance is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/#/feature_tap_dance).


### PR DESCRIPTION
Fix various minor nits throughout the site:

* spelling
* grammar
* headings level
* missing ending `;` in enum examples
* replace "->" arrows with "&rarr;"

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*) to incorporate these misc fixes in isolation.