### PR TITLE
Add any-key.md on using "Any" key to assign arbitrary QMK keycodes.

### DIFF
--- a/docs/manual/any-key.md
+++ b/docs/manual/any-key.md
@@ -1,0 +1,65 @@
+---
+layout: default
+title: Any key
+parent: User manual
+nav_order: 8
+---
+
+# Any key
+
+The Basic tab has a special "`Any`" key. This is an escape hatch, useful to enter arbitrary keycodes that are **known to be supported in your build on the firmware** but not otherwise accessible in the GUI. Assigning "`Any`" to a key opens a dialog box where you can entry an arbitrary keycode. Alternatively, double click a keymap key to open this dialog.
+
+## Textual entry
+
+One way to enter a keycode is by its name or syntax as would be used when editing a QMK `keymap.c` in C, provided this name is known to the configurator. See the [full list of QMK keycodes](https://docs.qmk.fm/keycodes) for known keycode names. Macro syntax like `LSFT(kc)` and `MT(mod, kc)` is supported as well. In this way, it is possible to enter certain keys like [LM layer mod](https://docs.qmk.fm/feature_layers) keys and modifier combinations that are not otherwise exposed.
+
+*Examples:*
+
+| Syntax                          | Meaning                                    |
+|---------------------------------|--------------------------------------------|
+| `KC_ENT`                        | Enter key                                  |
+| `C(KC_V)`                       | Left Ctrl + V                              |
+| `C(S(KC_V))`                    | Left Ctrl + Left Shift + V                 |
+| `RSA(KC_V)`                     | Right Shift + Right Alt + V                |
+| `LM(2, MOD_LSFT)`               | Layer 2 + Left Shift layer mod switch.     |
+| `OSM(MOD_LSFT | MOD_LGUI)`      | One-shot Left Shift + Left GUI             |
+| `MT(MOD_RSFT | MOD_RALT, KC_A)` | Right Shift + Right Alt on hold, A on tap  |
+
+Refer to the [QMK documentation](https://docs.qmk.fm) for full explanation of keycode syntax.
+
+
+## Numeric entry
+
+Another way to enter a key is numerically by its 16-bit keycode. Even when the key isn't known to the configurator by name, it is yet possible to enter the key in this way. It's a tedious process, but it does work to assign keys that would be otherwise unavailable. Of course, this only works provided you determine the correct numeric value for the keycode and your build of the firmware supports that keycode. Otherwise, the key will likely do nothing.
+
+### How to determine numeric keycodes?
+
+One way to deduce the numeric keycode values is by referring to the firmware source files that define them. The keycodes are defined in [quantum/keycodes.h](https://github.com/vial-kb/vial-qmk/blob/vial/quantum/keycodes.h), whereas preprocessor macros like `LSFT(kc)` are defined in [quantum/quantum\_keycodes.h](https://github.com/vial-kb/vial-qmk/blob/vial/quantum/quantum_keycodes.h).
+
+*Example:* Suppose we have made a custom build of Vial in which [Swap Hands](https://docs.qmk.fm/features/swap_hands), which Vial does not natively support, was enabled through "`SWAP_HANDS_ENABLE = yes`" in `vial/rules.mk` when building the firmware. Swap Hands defines several feature-specific keys, such as `SH_MON`, `SH_OS`, and `SH_T(kc)`, which the configurator does not know.
+
+> Important
+> {: .label .label-red }
+> The numeric values of the keycodes may differ between different versions of QMK. Verify keycode values for your version of the firmware.
+
+We can find `SH_MON` and `SH_OS` (aka `QK_SWAP_HANDS_MOMENTARY_ON` and `QK_SWAP_HANDS_ONE_SHOT`) in `quantum/keycodes.h`:
+
+```c
+QK_SWAP_HANDS_MOMENTARY_ON = 0x56F2,
+QK_SWAP_HANDS_MOMENTARY_OFF = 0x56F3,
+QK_SWAP_HANDS_OFF = 0x56F4,
+QK_SWAP_HANDS_ON = 0x56F5,
+QK_SWAP_HANDS_ONE_SHOT = 0x56F6,
+// (more codes...)
+```
+
+This shows the keycodes (expressed in hexadecimal) are `SH_MON = 0x56F2` and `SH_OS = 0x56F6`. We can therefore assign `SH_MON` to a key in the configurator by first assigning `Any`, then entering `0x56F2`. Since the configurator does not recognize the keycode, it displays as the raw numeric value `0x56F2` in the GUI. The key does nevertheless function as `SH_MON` on the keyboard itself.
+
+Determining the keycode for `SH_T(kc)` is more complicated. Being a preprocessor macro, its definition is in `quantum/quantum_keycodes.h`:
+
+```c
+#define SH_T(kc) (QK_SWAP_HANDS | ((kc)&0xFF))
+```
+
+in which `QK_SWAP_HANDS` is `0x5600` (based on referring back to `quantum/keycodes.h`). For the key's "`kc`" placeholder, we can numerically substitute the keycode for any Basic key. For instance with `KC_A = 0x0004`, the full keycode for `SH_T(KC_A)` is `0x5604`.
+

--- a/docs/manual/quantum.md
+++ b/docs/manual/quantum.md
@@ -37,14 +37,14 @@ Use the following keys for a combination with multiple mods (to read these abbre
 
 These keys are assigned in two steps: First, select the outer part of the key from the Quantum tab. When placed, the key will display a nested placeholder, representing the inner "`kc`" part of the key. Select this nested area and choose a key from the Basic tab to complete the definition.
 
-The "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](https://docs.qmk.fm/mod_tap#caveats). Some mod combinations are not exposed in the GUI, but can be assigned through Any key entry, in which multiple mods can be composed with syntax like "`RALT(RSFT(KC_A))`" for Right Alt + Right Shift + `A`.
+The "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](https://docs.qmk.fm/mod_tap#caveats). Some mod combinations are not exposed in the GUI, but can be assigned through [Any key]({% link manual/any-key.md %}) entry, in which multiple mods can be composed with syntax like "`RALT(RSFT(KC_A))`" for Right Alt + Right Shift + `A`.
 
 
 ## Mod-tap keys
 
 Keys `LSft_T(kc)`, `LCtl_T(kc)`, etc. are mod-tap keys, named like the Modifier keys but with a "`_T`" suffix. These keys produce `kc` when tapped and act as a modifier when held ([QMK docs](https://docs.qmk.fm/mod_tap)).
 
-Like Modifier keys, the "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](https://docs.qmk.fm/mod_tap#caveats). Some mod combinations are not exposed in the GUI, but can be assigned through Any key entry like "`MT(MOD_RALT | MOD_RSFT, KC_A)`."
+Like Modifier keys, the "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](https://docs.qmk.fm/mod_tap#caveats). Some mod combinations are not exposed in the GUI, but can be assigned through [Any key]({% link manual/any-key.md %}) entry like "`MT(MOD_RALT | MOD_RSFT, KC_A)`."
 
 ### Tap-hold configuration
 
@@ -85,7 +85,7 @@ A suggested starting point for home row mods in Vial:
 
 The `OSM mod` keys are one-shot modifiers, aka sticky keys. One-shot modifiers remain active until the next key is pressed, and are then released ([QMK docs](https://docs.qmk.fm/one_shot_keys)).
 
-Some mod combinations are not exposed in the GUI, but can be assigned through Any key entry with syntax like "`OSM(MOD_RALT | MOD_RSFT)`" for one-shot Right Alt + Right Shift.
+Some mod combinations are not exposed in the GUI, but can be assigned through [Any key]({% link manual/any-key.md %}) entry with syntax like "`OSM(MOD_RALT | MOD_RSFT)`" for one-shot Right Alt + Right Shift.
 
 
 ## Repeat Key


### PR DESCRIPTION
Adds new page `manual/any-key.md` about "Any" key arbitrary keycode assignment.

## Details

The "Any" key is a powerful, low-level feature in Vial. This PR adds a dedicated page about it.

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*) to propose the any-key.md page in isolation.