### PR TITLE
Modernize linking with Jekyll's {% link path/file.md %} syntax.

### DIFF
--- a/docs/docs/encoders.md
+++ b/docs/docs/encoders.md
@@ -13,7 +13,7 @@ redirect_from:
 
 Vial implements optional GUI configuration for rotary encoders. This allows users to set up separate keycode actions for clockwise and counterclockwise encoder rotations. Encoders fully support QMK layers, so different keycodes can be used for different layers.
 
-You will need to port your keyboard over to Vial before encoders are supported. Follow [Step 1](/porting-to-via.md) and [Step 2](/porting-to-vial.md) to get started.
+You will need to port your keyboard over to Vial before encoders are supported. Follow [Step 1]({% link docs/porting-to-via.md %}) and [Step 2]({% link docs/porting-to-vial.md %}) to get started.
 
 In order to enable encoder support in your firmware, follow these steps:
 

--- a/docs/docs/porting-to-via.md
+++ b/docs/docs/porting-to-via.md
@@ -227,6 +227,6 @@ If the layout is showing incorrectly, or loading the file results in an error me
 
 ## Done!
 
-This should be enough to get you a basic keyboard definition JSON file. Next, move onto [building Vial support](/porting-to-vial.md).
+This should be enough to get you a basic keyboard definition JSON file. Next, move onto [building Vial support]({% link docs/porting-to-vial.md %}).
 
 Did you run into a problem? You can get porting support by joining [Vial discord](https://discord.gg/zNKEUXTKwF).

--- a/docs/docs/porting-to-vial.md
+++ b/docs/docs/porting-to-vial.md
@@ -116,7 +116,7 @@ The last line should match what you got in the previous step. <sup>[(example)](h
 
 ## 6. Set up a secure unlock combination
 
-Vial needs a key combination in order to protect the user from a malicious host computer unknowingly changing security-sensitive settings, such as flashing a malicious firmware; for more information see [here](security.md).
+Vial needs a key combination in order to protect the user from a malicious host computer unknowingly changing security-sensitive settings, such as flashing a malicious firmware; for more information see [here]({% link docs/security.md %}).
 
 If you do not want to utilize this feature, you should set `VIAL_INSECURE = yes` in your `keymaps/vial/rules.mk`. While you can distribute the resulting firmware to your users and will not lose any Vial functionality, note that keyboards which enable `VIAL_INSECURE` will not be accepted to the main `vial-qmk` repository.
 
@@ -138,7 +138,7 @@ After you flash the firmware, check that the function works correctly by activat
 
 ## 7. Compile Vial firmware for your keyboard
 
-Compiling and flashing can be done in the same way as QMK. For example, to compile a `vial` keymap for a keyboard located under `keyboards/xyz/xyz60`, run `make xyz/xyz60:vial` from the root `vial-qmk` directory. If at this point you're having issues making the firmware fit (running out of flash, RAM or EEPROM), see [this guide](firmware-size.md) for how to reduce Vial firmware size.
+Compiling and flashing can be done in the same way as QMK. For example, to compile a `vial` keymap for a keyboard located under `keyboards/xyz/xyz60`, run `make xyz/xyz60:vial` from the root `vial-qmk` directory. If at this point you're having issues making the firmware fit (running out of flash, RAM or EEPROM), see [this guide]({% link docs/firmware-size.md %}) for how to reduce Vial firmware size.
 
 ## Done!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,7 +12,7 @@ nav_order: 1
 
 [Start Vial Web](https://vial.rocks/){: .btn .gettingStarted .blue target="_blank"}
 [Download Vial](/download){: .btn .gettingStarted .blue}
-[Read user manual](/manual/){: .btn .gettingStarted}
+[Read user manual]({% link manual/index.md %}){: .btn .gettingStarted}
 [Join our Discord server](https://discord.gg/zNKEUXTKwF){: .btn .gettingStarted}
 
 To get started using Vial, install a Vial-compatible firmware on your keyboard (if it did not come preloaded with one) and it will be automatically detected by the Vial GUI.

--- a/docs/manual/alt-repeat-key.md
+++ b/docs/manual/alt-repeat-key.md
@@ -52,7 +52,7 @@ Note: LCtl can be found under the Quantum tab.
 
 Define Alt Repeat after the `K` key to type "`eyboard`", producing "`keyboard`".
 
-First, [define a macro](macro.md), say `M3`, to type the text "`eyboard`". Then add an Alt Repeat rule with
+First, [define a macro]({% link manual/macros.md %}), say `M3`, to type the text "`eyboard`". Then add an Alt Repeat rule with
 
 * Last key: `K`
 * Alt key: `M3`

--- a/docs/manual/first-use.md
+++ b/docs/manual/first-use.md
@@ -68,4 +68,4 @@ To compile and flash Vial firmware yourself using the command line tools:
 4. Use QMK to flash your keyboard with the `vial` keymap. (This will not work if your keyboard has not been ported to Vial.) This looks like `qmk flash -kb <insert_keyboard> -km vial`.
 
 If your keyboard doesn't show up after flashing Vial firmware, and you're on Linux, 
-[you may need to add udev rules.](https://get.vial.today/manual/linux-udev.html)
+[you may need to add udev rules.]({% link manual/linux-udev.md %})

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -8,7 +8,7 @@ nav_order: 2
 # Layers
 Layers provide the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Keys can be configured to switch between layers as needed similar to function keys on a laptop. 
 
-Most Vial devices have 4 layers but this number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
+Most Vial devices have 4 layers but this number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
 
 You can view each layer available by clicking the corresponding number at the top of the interface. You can see we already have layer 0 selected.
 

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 Macros can be used to perform a pre-programmed sequence of actions or steps. 
 
-By default, 16 macros can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
+By default, 16 macros can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
 
 Some great example uses for macros could be typing out an address, opening a program with a hotkey-shortcut or filling out a form.
 

--- a/docs/manual/tap-dance.md
+++ b/docs/manual/tap-dance.md
@@ -10,7 +10,7 @@ nav_order: 4
 Tap Dance allows you to configure different actions depending on how a button is used. For example, the same button could be configured to active a macro when the button is tapped or activate something else when the button is held.
 
 ## 1. Configuring Tap Dance
-Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap dances can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
+Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap dances can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
 
 ![](../img/tap-tabs.png)
 


### PR DESCRIPTION
This PR applies [Jekyll's link syntax](https://jekyllrb.com/docs/liquid/tags/#links) `{% link path/file.md %}` syntax for internal links throughout the site. The advantage is that broken links are detected when compiling the site.

## Details

Essentially, the change is:

**Old**
```md
[link text](path/to/page.md)
```

**New**
```md
[link text]({% link path/to/page.md %})
```

Links with anchors are possible as well with syntax like `[link text]({% link path/to/page.md %}#subsection-title)`.


This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*).