### PR TITLE
Add alt text for accessibility to most images.

### DIFF
--- a/docs/docs/custom_keycode.md
+++ b/docs/docs/custom_keycode.md
@@ -37,7 +37,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 
 When you load a board with custom keycodes, they will appear as unique hexcode. You can use the "any key" button and type in values starting with `0x7E40` to assign them but this isn't very user friendly.
 
-![](/img/vial_before.png)
+![Custom keycodes showing as hex values before defining them in vial.json](/img/vial_before.png)
 
 ## Custom keycodes in Vial
 
@@ -85,6 +85,6 @@ Custom keycodes in the json file __must__ match what's inside the enum block, bo
 
 If everything goes smoothly the hexcode will be replaced with name of the keycode. You can access all your custom keycode inside the User tab. Do note that the firmware size will increase slightly (this example is ~100bytes).
 
-![](/img/vial_after.png)
+![Custom keycodes showing named aliases after configuration](/img/vial_after.png)
 
-![](/img/user_tab.png)
+![User tab in Vial showing custom keycodes](/img/user_tab.png)

--- a/docs/docs/porting-to-vial.md
+++ b/docs/docs/porting-to-vial.md
@@ -39,13 +39,13 @@ The second part of this tutorial will guide you through porting your keyboard to
    - If you are unfamiliar with git, and want a GUI version, install the [GitHub Desktop](https://desktop.github.com) version for your OS. Go to [https://github.com/vial-kb/vial-qmk](https://github.com/vial-kb/vial-qmk) and select "Open in Github Desktop". Follow the guided download/cloning.
    - **Reference Guide:** Run `git clone https://github.com/vial-kb/vial-qmk`.
 
-![](../img/open_to_github_desktop.png)
+![Opening vial-qmk in GitHub Desktop](../img/open_to_github_desktop.png)
 
 2. Install the prerequisites for compilation.
   - Open the QMK command line environment and navigate to your new `vial-qmk` folder to run the above command. Refer to [this guide](https://developer.mozilla.org/en-US/docs/Learn/Tools_and_testing/Understanding_client-side_tools/Command_line#basic_built-in_terminal_commands) on how-to. In the image below, notice how it says 'vial-qmk' at the end of the prompt. This is your confirmation you have found the correct directory.
    - **Reference Guide:** Run `make git-submodule` in your new `vial-qmk` directory to clone the git submodules.
 
-![](../img/beginner_prompt.png)
+![Terminal prompt showing the vial-qmk directory](../img/beginner_prompt.png)
 
 3. Verify that your installation is complete by running `qmk doctor`.
    - If you have added a new keyboard folder as part of your port, you will see `Git has unstashed/uncommitted changes.` Other than that, the only warning should be `The official repository does not seem to be configured as git remote "upstream".` (This is fine because Vial-QMK is not the official QMK repository.)

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,4 +21,4 @@ Vial is a completely open project with sources for all components publicly avail
 
 Have a feature suggestion for Vial? Feel free to submit it at the dedicated [feedback website](https://feedback.vial.today/).
 
-![](img/vial-win-1.png)
+![Screenshot of the Vial configurator GUI](img/vial-win-1.png)

--- a/docs/manual/alt-repeat-key.md
+++ b/docs/manual/alt-repeat-key.md
@@ -18,7 +18,7 @@ The Alt Repeat Key can be configured. It can be used as a "magic" or "adaptive" 
 
 Click the **Alt Repeat Key** tab at the top of the window and one of the available numbers below it to edit a configuration rule. 
 
-![](../img/alt-repeat-key.png)
+![Alt Repeat Key tab showing configurable entries](../img/alt-repeat-key.png)
 
 Each rule specifies:
 

--- a/docs/manual/combos.md
+++ b/docs/manual/combos.md
@@ -12,11 +12,11 @@ Combos allow you to add custom actions when a certain combination of keys is pre
 ## 1. Combos
 Click the **Combos** tab at the top and one of the available numbers below it. By default, 8 combos can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
 
-![](../img/combos-tab.png)
+![Combos tab showing configurable entries](../img/combos-tab.png)
 
 The settings for that particular combo will be shown. Up to 4 combination of keys can be configured to activate 1 action. Each key must be pressed within the combo term to be considered a combo. In the case below, pressing the `+/=` key and the `backspace` key will instead trigger the delete key.
 
-![](../img/combos-overview.png)
+![Combo configured to trigger Delete when pressing +/= and Backspace together](../img/combos-overview.png)
 
 ## 2. Using a Combo
 After the combo has been configured and saved, it can be used. There is no need to assign it to a specific key. 

--- a/docs/manual/first-use.md
+++ b/docs/manual/first-use.md
@@ -45,7 +45,7 @@ Using Vial is extremely simple, just click on a key you would like to change the
 
 Your new key will be automatically saved onto the keyboard and immediately ready for use.
 
-![](../img/vial-linux.png)
+![Screenshot of the Vial configurator GUI](../img/vial-linux.png)
 
 ## 4. My keyboard isn't discovered or it doesn't work.
 

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -12,15 +12,15 @@ Most Vial devices have 4 layers but this number can be adjusted in firmware at c
 
 You can view each layer available by clicking the corresponding number at the top of the interface. You can see we already have layer 0 selected.
 
-![](../img/layers-cycle.png)
+![Layer selector showing layers 0 through 3](../img/layers-cycle.png)
 
 A typical layer setup would include a "base" layer and a "Function" layer. 
 
 #### Base Layer
-![](../img/layers-layer-1.png)
+![Base layer keymap with standard key assignments](../img/layers-layer-1.png)
 
 #### Function Layer
-![](../img/layers-layer-2.png)
+![Function layer keymap with additional key assignments](../img/layers-layer-2.png)
 
 You can see additional key functionality is located on the "Function" layer. This is just convention, in reality you can do whatever you want with the layers.
 

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -32,20 +32,20 @@ When you are satisfied with the configuration of all macros, click **save** to s
 ### Examples
 1. Opens Task Manager on Windows by pressing Ctrl+Shift and then tapping Esc
 
-    ![](../img/macro-task-manager.png)
+    ![Macro configured to open Task Manager with Ctrl+Shift+Esc](../img/macro-task-manager.png)
 
 2. Launch a program on Windows by opening the Start Menu, typing out the program name, and pressing Enter.
 
-    ![](../img/macro-launch-vs-code.png)
+    ![Macro configured to launch VS Code from the Start Menu](../img/macro-launch-vs-code.png)
 
 3. Type out a street address
 
-    ![](../img/macro-street-address.png)
+    ![Macro configured to type a street address](../img/macro-street-address.png)
 
 ## 2. Using Macros
 After the macro has been configured, it can be used. Just click on a key you would like to use for a macro in the top palette then select your macro in the bottom palette. (under the macro tab)
 
-![](../img/macro-overview.png)
+![Selecting a macro key in the keymap](../img/macro-overview.png)
 
 ## More info
 Macros is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/#/feature_macros).

--- a/docs/manual/tap-dance.md
+++ b/docs/manual/tap-dance.md
@@ -12,11 +12,11 @@ Tap Dance allows you to configure different actions depending on how a button is
 ## 1. Configuring Tap Dance
 Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap dances can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
 
-![](../img/tap-tabs.png)
+![Tap Dance tab showing configurable entries](../img/tap-tabs.png)
 
 Each tap dance can be configured to do different actions based on how the button is pressed. In the case below, when the button is "Tapped"(**On tap**), the Left GUI is pressed but when the button is held(**On hold**), the button activates layer 1. The other two options (**On double tap**) and (**On tap + hold**) can also be configured.
 
-![](../img/tap-overview.png)
+![Tap Dance configuration showing On tap, On hold, On double tap, and On tap + hold actions](../img/tap-overview.png)
 
 The **tapping term** represents the timing on how the firmware distinguishes between the actions. If a button is held for longer than the tapping term it's considered a hold. If a button is held for shorter than the tapping term it's considered a tap.
 
@@ -25,7 +25,7 @@ When you are satisfied with the configuration of all tap dance configurations, c
 ## 2. Using a Tap Dance
 After the tap dance has been configured and saved, it can be used. Just click on a key you would like to use for a tap dance in the top palette then select your tap dance in the bottom palette. (under the Tap Dance tab)
 
-![](../img/tap-left-menu-example.png)
+![Selecting a Tap Dance key in the bottom palette](../img/tap-left-menu-example.png)
 
 ## More info
 Tap Dance is a QMK feature and more detailed information can be found with the [official QMK documentation](https://docs.qmk.fm/#/feature_tap_dance).


### PR DESCRIPTION
For accessibility, this PR adds descriptive alt text to most images in the site.

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*)