### PR TITLE
Update documentation on configurable feature entry limits for combos, tap dance, etc.

### DIFF
--- a/docs/docs/firmware-size.md
+++ b/docs/docs/firmware-size.md
@@ -41,6 +41,31 @@ To turn off this feature and reduce compiled firmware size, RAM and EEPROM usage
 QMK_SETTINGS = no
 ```
 
+## Dynamic keymap layers
+
+By default Vial is configured to have 4 keymap layers. If the keyboard's microcontroller has sufficient free space, you can edit `config.h` to increase these limits. Or conversely, limits may be decreased to recover memory. To reduce EEPROM usage, you can define the following in your `config.h` file:
+
+```c
+#define DYNAMIC_KEYMAP_LAYER_COUNT 2
+```
+
+The max possible layers supported is 32 (QMK's limit).
+
+
+## Macros
+
+Macros is the GUI equivalent of [QMK's Macros](https://docs.qmk.fm/feature_macros) with the difference that Vial's macros are dynamically configurable in the GUI. A macro defines a sequence of key events to be sent to the computer when the macro is triggered.
+
+### Configure memory usage
+
+By default, the number of available Macros is calculated from the EEPROM size on your controller. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+
+```c
+#define DYNAMIC_KEYMAP_MACRO_COUNT x
+```
+
+Where `x` is the desired number of macro entries.
+
 ## Tap Dance
 
 Tap Dance is the GUI equivalent to [QMK's Tap Dance](https://docs.qmk.fm/#/feature_tap_dance) and can do pretty much what it does, with minor differences as you assign it in GUI rather than code. Tap the comma key, and you get a comma. Tap it twice and you get a semicolon.
@@ -123,14 +148,6 @@ To turn off this feature completely, and also reduce compiled firmware size, EEP
 
 ```
 REPEAT_KEY_ENABLE  = no
-```
-
-## Reducing dynamic keymap layers
-
-By default Vial is configured to have 4 keymap layers, To reduce EEPROM usage, you can define the following in your `config.h` file:
-
-```
-#define DYNAMIC_KEYMAP_LAYER_COUNT 2
 ```
 
 ## Enable LTO

--- a/docs/docs/firmware-size.md
+++ b/docs/docs/firmware-size.md
@@ -58,7 +58,7 @@ Macros is the GUI equivalent of [QMK's Macros](https://docs.qmk.fm/feature_macro
 
 ### Configure memory usage
 
-By default, the number of available Macros is calculated from the EEPROM size on your controller. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
+By default, 16 macros can be configured. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
 ```c
 #define DYNAMIC_KEYMAP_MACRO_COUNT x

--- a/docs/manual/alt-repeat-key.md
+++ b/docs/manual/alt-repeat-key.md
@@ -16,7 +16,7 @@ The Alt Repeat Key can be configured. It can be used as a "magic" or "adaptive" 
 
 ## Configuring Alt Repeat Key
 
-Click the **Alt Repeat Key** tab at the top of the window and one of the available numbers below it to edit a configuration rule. 
+Click the **Alt Repeat Key** tab at the top of the window and one of the available numbers below it to edit a configuration rule. By default, the number of configurable Alt Repeat Key entries is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#alt-repeat-key) at compile time (not the GUI) when building firmware.
 
 ![](../img/alt-repeat-key.png)
 

--- a/docs/manual/combos.md
+++ b/docs/manual/combos.md
@@ -7,10 +7,10 @@ nav_order: 5
 
 # Combos
 
-Combos allow you to add custom actions when a certain combination of keys is pressed. for example, hitting `A` and `S` within the combo term would hit `ESC` instead, or have it perform even more complex tasks.
+Combos allow you to add custom actions when a certain combination of keys is pressed. For example, hitting `A` and `S` within the combo term would hit `ESC` instead, or have it perform even more complex tasks.
 
 ## 1. Combos
-Click the **Combos** tab at the top and one of the available numbers below it. By default, 8 combos can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here](https://get.vial.today/docs/firmware-size.html) for more info.
+Click the **Combos** tab at the top and one of the available numbers below it. By default, the number of configurable combos is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#combos) at compile time (not the GUI) when building firmware.
 
 ![](../img/combos-tab.png)
 

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -8,7 +8,7 @@ nav_order: 2
 # Layers
 Layers provide the ability to change the functionality of the entire keyboard based on what "layer" it's currently on. It's best to visualize layers stacked on top of each other. Keys can be configured to switch between layers as needed similar to function keys on a laptop. 
 
-Most Vial devices have 4 layers but this number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
+By default, Vial supports up to 4 keymap layers. This limit [can be adjusted]({% link docs/firmware-size.md %}#dynamic-keymap-layers) at compile time (not the GUI) when building firmware.
 
 You can view each layer available by clicking the corresponding number at the top of the interface. You can see we already have layer 0 selected.
 

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 Macros can be used to perform a pre-programmed sequence of actions or steps. 
 
-By default, 16 macros can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
+By default, the number of configurable macros is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#macros) at compile time (not the GUI) when building firmware.
 
 Some great example uses for macros could be typing out an address, opening a program with a hotkey-shortcut or filling out a form.
 
@@ -19,7 +19,7 @@ Click the **Macros** tab. All the macros that can be configured will be displaye
 ![](../img/macros-header1.png)
 
 The next step is to add actions. In the bottom right corner, you can 
-* **Add action** - Manually adds an action to the list. Configure it to do exactly what you want. select from different options - hold, tap, release, and delay.
+* **Add action** - Manually adds an action to the list. Configure it to do exactly what you want. Select from different options - hold, tap, release, and delay.
 * **Tap Enter** - Lots of macros end with an "Enter" key so this button makes it easier to add that.
 * **Record macro** - Lets you record the macro directly from your keyboard. It's not the most reliable but it's a great place to start.
 

--- a/docs/manual/macros.md
+++ b/docs/manual/macros.md
@@ -9,7 +9,7 @@ nav_order: 3
 
 Macros can be used to perform a pre-programmed sequence of actions or steps. 
 
-By default, the number of configurable macros is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#macros) at compile time (not the GUI) when building firmware.
+By default, 16 macros can be configured. This limit [can be adjusted]({% link docs/firmware-size.md %}#macros) at compile time (not the GUI) when building firmware.
 
 Some great example uses for macros could be typing out an address, opening a program with a hotkey-shortcut or filling out a form.
 

--- a/docs/manual/tap-dance.md
+++ b/docs/manual/tap-dance.md
@@ -10,7 +10,7 @@ nav_order: 4
 Tap Dance allows you to configure different actions depending on how a button is used. For example, the same button could be configured to active a macro when the button is tapped or activate something else when the button is held.
 
 ## 1. Configuring Tap Dance
-Click the **Tap Dance** tab at the top and one of the available numbers below it. By default, 8 Tap dances can be configured. This number can be adjusted in firmware at compile (Not GUI) see [here]({% link docs/firmware-size.md %}) for more info.
+Click the **Tap Dances** tab at the top and one of the available numbers below it. By default, the number of configurable Tap Dance entries is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#tap-dance) at compile time (not the GUI) when building firmware.
 
 ![](../img/tap-tabs.png)
 


### PR DESCRIPTION
This PR updates documentation related to feature limits.

## Details

* Added subsection to firmware-size.md about macros.
* Moved up subsection about dynamic layers to appear earlier, since this one is probably most important.
* Updated stated limits in manual feature pages to say "the number of configurable entries is calculated from the EEPROM size" where they are conditional on `TOTAL_EEPROM_BYTE_COUNT` in [quantum/vial.h](https://github.com/vial-kb/vial-qmk/blob/vial/quantum/vial.h).

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*).