### PR TITLE
Add brief overview descriptions before TOCs for navigation.

### DIFF
--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -4,3 +4,10 @@ title: Porting guide
 nav_order: 3
 has_children: true
 ---
+
+# Porting guide
+
+This section is for **keyboard designers and firmware developers** who want to add Vial support to a keyboard. It walks through creating a keyboard definition JSON, porting the firmware, and configuring optional features like rotary encoders, lighting, and MIDI.
+
+If you are an end user looking to configure your keyboard, see the [User manual]({% link manual/index.md %}) instead.
+

--- a/docs/manual/index.md
+++ b/docs/manual/index.md
@@ -6,3 +6,10 @@ has_children: true
 redirect_from:
   - /gettingStarted/
 ---
+
+# User manual
+
+This section is for Vial end users who want to configure their keyboard using the Vial GUI. It covers editing keymaps and using features such as layers, macros, combos, and tap dance.
+
+If you are a **keyboard designer or firmware developer** looking to add Vial support to a keyboard, see the [Porting guide]({% link docs/index.md %}) instead.
+


### PR DESCRIPTION
Adds brief overviews above the User manual and Porting guide TOCs, describing what and for whom each is for.

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*).