### PR TITLE
Fancy styling of keys and other format tweaking.

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -143,3 +143,19 @@ blockquote {
   width: 30%;
   height: 30%;
 }
+
+kbd {
+  font-family: inherit;
+  font-size: 0.85em;
+  color: #f8f9fa;
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  vertical-align: middle;
+  background-color: #353945;
+  border: 2px solid #8d939c;
+  border-radius: 0.5rem;
+}
+
+kbd i {
+  color: #a5acb9;
+}

--- a/docs/docs/custom_keycode.md
+++ b/docs/docs/custom_keycode.md
@@ -7,6 +7,8 @@ redirect_from:
   - /manual/custom_keycode.html
 ---
 
+# Custom keycodes
+
 ## Custom keycodes in QMK
 
 QMK provides [a way](https://github.com/qmk/qmk_firmware/blob/master/docs/custom_quantum_functions.md) for users to redefine behavior for existing keys or create new keycodes.
@@ -35,7 +37,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
 }
 ```
 
-When you load a board with custom keycodes, they will appear as unique hexcode. You can use the "any key" button and type in values starting with `0x7E40` to assign them but this isn't very user friendly.
+When you load a board with custom keycodes, they will appear as unique hexcode. You can use [Any key]({% link manual/any-key.md%}) entry with values starting with `0x7E40` to assign them but this isn't very user friendly.
 
 ![Custom keycodes showing as hex values before defining them in vial.json](/img/vial_before.png)
 

--- a/docs/docs/firmware-size.md
+++ b/docs/docs/firmware-size.md
@@ -37,7 +37,7 @@ QMK Settings allows you to configure settings for all the other GUI features, li
 
 To turn off this feature and reduce compiled firmware size, RAM and EEPROM usage, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 QMK_SETTINGS = no
 ```
 
@@ -74,7 +74,7 @@ Tap Dance is the GUI equivalent to [QMK's Tap Dance](https://docs.qmk.fm/#/featu
 
 By default, the number of available Tap Dances is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`
 
-```
+```c
 #define VIAL_TAP_DANCE_ENTRIES x
 ```
 
@@ -82,7 +82,7 @@ Where `x` is the number of slots you desire.
 
 To turn off this feature completely, and also reduce compiled firmware size, EEPROM and RAM usage, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 TAP_DANCE_ENABLE = no
 ```
 
@@ -94,7 +94,7 @@ Combos are the GUI equivalent to [QMK's Combos](https://docs.qmk.fm/#/feature_co
 
 By default, the number of available Combos is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
-```
+```c
 #define VIAL_COMBO_ENTRIES x
 ```
 
@@ -102,7 +102,7 @@ Where `x` is the number of slots you desire.
 
 To turn off this feature completely, and also reduce compiled firmware size, EEPROM and RAM usage, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 COMBO_ENABLE = no
 ```
 
@@ -116,7 +116,7 @@ Don’t want shift + 1 to type ! on your computer? Use a key override to make yo
 
 By default, the number of available Key Overrides is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
-```
+```c
 #define VIAL_KEY_OVERRIDE_ENTRIES x
 ```
 
@@ -124,7 +124,7 @@ Where `x` is the number of slots you desire.
 
 To turn off this feature completely, and also reduce compiled firmware size, EEPROM and RAM usage, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 KEY_OVERRIDE_ENABLE = no
 ```
 
@@ -138,7 +138,7 @@ For example, after pressing `Ctrl + Shift + →` to select the next word, the Al
 
 By default, the number of available Alt Repeat keys is calculated from the amount of EEPROM your controller has. To reduce EEPROM usage or to select one feature over another, you can define the following in your `config.h`:
 
-```
+```c
 #define VIAL_ALT_REPEAT_KEY_ENTRIES x
 ```
 
@@ -146,7 +146,7 @@ Where `x` is the number of slots you desire.
 
 To turn off this feature completely, and also reduce compiled firmware size, EEPROM and RAM usage, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 REPEAT_KEY_ENABLE  = no
 ```
 
@@ -154,7 +154,7 @@ REPEAT_KEY_ENABLE  = no
 
 To enable LTO, add the following line to your `keymaps/vial/rules.mk`:
 
-```
+```make
 LTO_ENABLE = yes
 ```
 

--- a/docs/docs/midi.md
+++ b/docs/docs/midi.md
@@ -29,7 +29,7 @@ Add `MIDI_ENABLE = yes` to your `keymaps/vial/rules.mk` file.
 
 To enable **BASIC** or **ADVANCED** **MIDI** on Vial it is necessary to add one of these lines to the `vial.json` file
 
-```
+```json
 { "vial": {
         "midi": "basic"
         ...
@@ -40,7 +40,7 @@ To enable **BASIC** or **ADVANCED** **MIDI** on Vial it is necessary to add one 
 
 or
 
-```
+```json
 { "vial": {
         "midi": "advanced"
         ...

--- a/docs/docs/porting-to-via.md
+++ b/docs/docs/porting-to-via.md
@@ -48,7 +48,7 @@ Next, you will need to correlate physical keyboard layout to the switch matrix. 
 If the keyboard already has a QMK port, you can follow the `LAYOUT` macro in order to assign rows and columns to the keys in the KLE. For example, let's take a look at [m0110_usb](https://github.com/vial-kb/vial-qmk/blob/12950db4d8ec1f294b1285e9b554a8fdc0a4bc6d/keyboards/converter/m0110_usb/m0110_usb.h#L69-L90):
 
 
-```
+```c
 #define LAYOUT_ansi( \
     K32, K12, K13, K14, K15, K17, K16, K1A, K1C, K19, K1D, K1B, K18, K33,  K47, K68, K6D, K62, \
     K30, K0C, K0D, K0E, K0F, K11, K10, K20, K22, K1F, K23, K21, K1E,       K59, K5B, K5C, K4E, \

--- a/docs/docs/porting-to-vial.md
+++ b/docs/docs/porting-to-vial.md
@@ -70,7 +70,7 @@ Copy the existing `keymaps/default` folder to `keymaps/vial` with the content in
 
 Create a new file (or edit an existing one) under `[keyboard_name]/keymaps/vial/rules.mk` with the following contents:<sup>[(example)](https://github.com/vial-kb/vial-qmk/blob/90f3b0e2e188eccb23ed8a2a690df278a0f1057b/keyboards/vial_example/vial_atmega32u4/keymaps/vial/rules.mk#L2)</sup>
 
-```
+```make
 VIA_ENABLE = yes
 VIAL_ENABLE = yes
 ```
@@ -104,7 +104,7 @@ python3 util/vial_generate_keyboard_uid.py
 
 Create a new file under `[keyboard_name]/keymaps/vial/config.h` and add the following contents to it:
 
-```
+```c
 /* SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,8 +7,8 @@ nav_order: 1
 
 # Vial
 {: .my-1 }
-### **Vial is a feature-rich open-source cross-platform (Windows, Linux and Mac) GUI and a QMK fork for configuring your keyboard in real time.**
-{: .mt-1 .mb-8 .text-grey-dk-100 .line-height-fix }
+**Vial is a feature-rich open-source cross-platform (Windows, Linux and Mac) GUI and a QMK fork for configuring your keyboard in real time.**
+{: .mt-1 .mb-8 .text-grey-dk-100 .line-height-fix .fs-5 }
 
 [Start Vial Web](https://vial.rocks/){: .btn .gettingStarted .blue target="_blank"}
 [Download Vial](/download){: .btn .gettingStarted .blue}
@@ -19,6 +19,6 @@ To get started using Vial, install a Vial-compatible firmware on your keyboard (
 
 Vial is a completely open project with sources for all components publicly available on [GitHub](https://github.com/vial-kb). For information about using Vial and porting a new keyboard to Vial, read through the manual entries linked in the sidebar on the left.
 
-Have a feature suggestion for Vial? Feel free to submit it at the dedicated [feedback website](https://feedback.vial.today/).
+&#x1F4A1; Have a feature suggestion for Vial? Feel free to submit it at the dedicated [feedback website](https://feedback.vial.today/).
 
 ![Screenshot of the Vial configurator GUI](img/vial-win-1.png)

--- a/docs/manual/alt-repeat-key.md
+++ b/docs/manual/alt-repeat-key.md
@@ -38,14 +38,15 @@ A few practical use cases are described next.
 
 Define Alt Repeat after Ctrl+Z to perform Ctrl+Y, and vice versa (corresponding to Undo and Redo hotkeys in many programs):
 
-* Last key: LCtl(Z)
-* Alt key: LCtl(Y)
+* Last key: <kbd>LCtl(Z)</kbd>
+* Alt key: <kbd>LCtl(Y)</kbd>
 * Allowed mods: all unchecked
 * Default to this alt key: unchecked
 * Bidirectional: checked
 * Ignore mod handedness: checked
 
-Note: LCtl can be found under the Quantum tab.
+Note: <kbd>LCtl(<i>kc</i>)</kbd> can be found under the [Quantum tab]({% link
+manual/quantum.md %}#modifier-keys).
 
 
 ### Typing shortcut
@@ -54,8 +55,8 @@ Define Alt Repeat after the `K` key to type "`eyboard`", producing "`keyboard`".
 
 First, [define a macro]({% link manual/macros.md %}), say `M3`, to type the text "`eyboard`". Then add an Alt Repeat rule with
 
-* Last key: `K`
-* Alt key: `M3`
+* Last key: <kbd>K</kbd>
+* Alt key: <kbd>M3</kbd>
 * Allowed mods: LShift and RShift checked
 * Default to this alt key: unchecked
 * Bidirectional: unchecked
@@ -68,8 +69,8 @@ Suppose we want Alt Repeat to behave as `U` when typed after `A`, and otherwise 
 
 Rule 1:
 
-* Last key: `A`
-* Alt key: `U`
+* Last key: <kbd>A</kbd>
+* Alt key: <kbd>U</kbd>
 * Allowed mods: LShift and RShift checked
 * Default to this alt key: unchecked
 * Bidirectional: unchecked
@@ -78,7 +79,7 @@ Rule 1:
 Rule 2:
 
 * Last key: (anything)
-* Alt key: `H`
+* Alt key: <kbd>H</kbd>
 * Allowed mods: all checked
 * Default to this alt key: checked
 * Bidirectional: unchecked

--- a/docs/manual/any-key.md
+++ b/docs/manual/any-key.md
@@ -7,7 +7,7 @@ nav_order: 8
 
 # Any key
 
-The Basic tab has a special "`Any`" key. This is an escape hatch, useful to enter arbitrary keycodes that are **known to be supported in your build on the firmware** but not otherwise accessible in the GUI. Assigning "`Any`" to a key opens a dialog box where you can entry an arbitrary keycode. Alternatively, double click a keymap key to open this dialog.
+The Basic tab has a special <kbd>Any</kbd> key. This is an escape hatch, useful to enter arbitrary keycodes that are **known to be supported in your build on the firmware** but not otherwise accessible in the GUI. Assigning "`Any`" to a key opens a dialog box where you can entry an arbitrary keycode. Alternatively, double click a keymap key to open this dialog.
 
 ## Textual entry
 

--- a/docs/manual/combos.md
+++ b/docs/manual/combos.md
@@ -7,14 +7,14 @@ nav_order: 5
 
 # Combos
 
-Combos allow you to add custom actions when a certain combination of keys is pressed. For example, hitting `A` and `S` within the combo term would hit `ESC` instead, or have it perform even more complex tasks.
+Combos allow you to add custom actions when a certain combination of keys is pressed. For example, hitting <kbd>A</kbd> and <kbd>S</kbd> within the combo term would produce `Escape` instead, or have it perform even more complex tasks.
 
 ## 1. Combos
 Click the **Combos** tab at the top and one of the available numbers below it. By default, the number of configurable combos is calculated from the EEPROM size on your keyboard's microcontroller. This limit [can be adjusted]({% link docs/firmware-size.md %}#combos) at compile time (not the GUI) when building firmware.
 
 ![Combos tab showing configurable entries](../img/combos-tab.png)
 
-The settings for that particular combo will be shown. Up to 4 combination of keys can be configured to activate 1 action. Each key must be pressed within the combo term to be considered a combo. In the case below, pressing the `+/=` key and the `backspace` key will instead trigger the delete key.
+The settings for that particular combo will be shown. Up to 4 combination of keys can be configured to activate 1 action. Each key must be pressed within the combo term to be considered a combo. In the case below, pressing the <kbd>+/=</kbd> key and the <kbd>Backspace</kbd> key will instead trigger the Delete key.
 
 ![Combo configured to trigger Delete when pressing +/= and Backspace together](../img/combos-overview.png)
 

--- a/docs/manual/layers.md
+++ b/docs/manual/layers.md
@@ -27,15 +27,15 @@ You can see additional key functionality is located on the "Function" layer. Thi
 ## Moving Between Layers
 Switching between what layer is active can be done in a few ways. In the lower palette, select the **layer** tab to view all the different options. 
 
-- `MO(layer)` - momentarily activates the layer. As soon as you let go of the key, the layer is deactivated.
-- `DF(layer)` - changes which layer is the default layer. This stays until the device loses power.
-- `PDF(layer)` - persistently sets the default layer. This layer setting is saved even when the device loses power.
-- `TG(layer)` - toggles the layer, activating it if it's inactive and vice versa.
-- `TO(layer)` - activates *layer* and deactivates all others.
-- `TT(layer)` - If you hold the key down, the layer is activated, and then is de-activated when you let go (like `MO`). If you repeatedly tap it, the layer will be toggled on or off (like `TG`). It needs 5 taps to do this.
-- `OSL(layer)` - momentarily activates the layer until the next key is pressed.
-- `LT layer (kc)` - momentarily activates the layer when it is held, sends a keycode when pressed. The keycode can be defined like all the other buttons, Just select the smaller box inside.
-- `Layer Lock` - "locks" the current layer to stay on, supposing it was accessed by a `MO`, `LT`, `OSL`, or `TT` layer switch. Pressing Layer Lock again unlocks the layer.
+- <kbd>MO(<i>layer</i>)</kbd> - momentarily activates the layer. As soon as you let go of the key, the layer is deactivated.
+- <kbd>DF(<i>layer</i>)</kbd> - changes which layer is the default layer. This stays until the device loses power.
+- <kbd>PDF(<i>layer</i>)</kbd> - persistently sets the default layer. This layer setting is saved even when the device loses power.
+- <kbd>TG(<i>layer</i>)</kbd> - toggles the layer, activating it if it's inactive and vice versa.
+- <kbd>TO(<i>layer</i>)</kbd> - activates *layer* and deactivates all others.
+- <kbd>TT(<i>layer</i>)</kbd> - If you hold the key down, the layer is activated, and then is de-activated when you let go (like `MO`). If you repeatedly tap it, the layer will be toggled on or off (like `TG`). It needs 5 taps to do this.
+- <kbd>OSL(<i>layer</i>)</kbd> - momentarily activates the layer until the next key is pressed.
+- <kbd>LT <i>layer</i> (<i>kc</i>)</kbd> - momentarily activates the layer when it is held, sends a keycode when pressed. The keycode can be defined like all the other buttons, Just select the smaller box inside.
+- <kbd>Layer Lock</kbd> - "locks" the current layer to stay on, supposing it was accessed by a `MO`, `LT`, `OSL`, or `TT` layer switch. Pressing Layer Lock again unlocks the layer.
 
 The keymap behaves as a stack of layers in which **multiple layers can be active at once**. Higher layers take precedence, stacking on top of lower layers. Usually, you want a layer switch key on layer *n* to activate layer *n*+1 or higher. If you do want to drop down from a higher layer to a lower layer, use a "`TO`" layer switch.
 
@@ -44,4 +44,4 @@ mods. Layer mod switches are not exposed in the GUI, but can be assigned through
 
 
 ## Transparency
-The Triangle ▽ symbols represent Transparency. Those mean the action is the same as the layer below it. This is useful so that keys from different layers can be pressed at the same time. 
+The Triangle <kbd>▽</kbd> symbols represent Transparency. Those mean the action is the same as the layer below it. This is useful so that keys from different layers can be pressed at the same time. 

--- a/docs/manual/linux-udev.md
+++ b/docs/manual/linux-udev.md
@@ -20,7 +20,7 @@ The following guides will show you how to implement these `udev` rules. You will
 
 For a universal access rule for any device with Vial firmware, run this in your shell while logged in as your user (this will only work with `sudo` installed):
 
-```
+```bash
 export USER_GID=`id -g`; sudo --preserve-env=USER_GID sh -c 'echo "KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", ATTRS{serial}==\"*vial:f64c2b3c*\", MODE=\"0660\", GROUP=\"$USER_GID\", TAG+=\"uaccess\", TAG+=\"udev-acl\"" > /etc/udev/rules.d/59-vial.rules && udevadm control --reload && udevadm trigger'
 ```
 
@@ -49,7 +49,7 @@ On a kernel level, there is no way to detect if a keyboard is compatible with VI
 
 For a rule that allows users to access all `hidraw` devices, run this in your shell while logged in as your user (this will only work with `sudo` installed):
 
-```
+```bash
 export USER_GID=`id -g`; sudo --preserve-env=USER_GID sh -c 'echo "KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", MODE=\"0660\", GROUP=\"$USER_GID\", TAG+=\"uaccess\", TAG+=\"udev-acl\"" > /etc/udev/rules.d/92-viia.rules && udevadm control --reload && udevadm trigger' 
 ```
 
@@ -107,7 +107,7 @@ KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{serial}=="*vial:f64c2b3c*", ATTRS{
 
 In order for your new `udev` rules to take effect, you must reload the `udev` rules. The standard way to do this is to run the following command as root:
 
-```
+```bash
 udevadm control --reload-rules && udevadm trigger
 ```
 

--- a/docs/manual/quantum.md
+++ b/docs/manual/quantum.md
@@ -13,7 +13,7 @@ You can find many of QMK's feature under the keymap view in the **Quantum** tab.
 
 ## Caps Word
 
-The `Caps Word` key activates Caps Word, capitalizing until end of current word ([QMK docs](https://docs.qmk.fm/features/caps_word)). This key is useful to type a single word in all capitals, like abbreviations.
+The <kbd>Caps Word</kbd> key activates Caps Word, capitalizing until end of current word ([QMK docs](https://docs.qmk.fm/features/caps_word)). This key is useful to type a single word in all capitals, like abbreviations.
 
 Caps Word automatically disables once a "word breaking key" is pressed, that is, once Space or anything other than letters A&ndash;Z, digits 0&ndash;9, `-`, `_`, Delete, or Backspace is pressed.
 
@@ -22,7 +22,7 @@ While active, `-` is shifted to `_`. This makes it easier to type e.g. `PROGRAM_
 
 ## Modifier keys
 
-The keys `LSft(kc)`, `LCtl(kc)`, etc. press a modifier (or a combination of multiple modifiers) together with a key "`kc`" ([QMK docs](https://docs.qmk.fm/feature_advanced_keycodes)). This kind of key is useful to send hotkey chords and AltGr+key combinations with a single physical key press. For instance, `LCtl(C)` sends Left Ctrl + `C`, and `RAlt(A)` sends Right Alt + `A`.
+The keys <kbd>LSft(<i>kc</i>)</kbd>, <kbd>LCtl(<i>kc</i>)</kbd>, etc. press a modifier (or a combination of multiple modifiers) together with a key "`kc`" ([QMK docs](https://docs.qmk.fm/feature_advanced_keycodes)). This kind of key is useful to send hotkey chords and AltGr+key combinations with a single physical key press. For instance, <kbd>LCtl(C)</kbd> sends Left Ctrl + `C`, and <kbd>RAlt(A)</kbd> sends Right Alt + `A`.
 
 Common aliases:
 * `LGui` and `RGui` are the Windows/Command/Super keys.
@@ -30,9 +30,9 @@ Common aliases:
 
 Use the following keys for a combination with multiple mods (to read these abbreviated names, "L" = Left, "R" = Right, and letters "CSAG" represent respectively Ctrl, Shift, Alt, GUI; see the [QMK docs](https://docs.qmk.fm/feature_advanced_keycodes) for the full list of such keys):
 
-* `LCS(kc)` = Left Ctrl + Shift + `kc`
-* `LSG(kc)` = Left Shift + GUI + `kc`
-* `RCG(kc)` = Right Ctrl + GUI + `kc`
+* <kbd>LCS(<i>kc</i>)</kbd> = Left Ctrl + Shift + `kc`
+* <kbd>LSG(<i>kc</i>)</kbd> = Left Shift + GUI + `kc`
+* <kbd>RCG(<i>kc</i>)</kbd> = Right Ctrl + GUI + `kc`
 * and so on.
 
 These keys are assigned in two steps: First, select the outer part of the key from the Quantum tab. When placed, the key will display a nested placeholder, representing the inner "`kc`" part of the key. Select this nested area and choose a key from the Basic tab to complete the definition.
@@ -42,7 +42,7 @@ The "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](h
 
 ## Mod-tap keys
 
-Keys `LSft_T(kc)`, `LCtl_T(kc)`, etc. are mod-tap keys, named like the Modifier keys but with a "`_T`" suffix. These keys produce `kc` when tapped and act as a modifier when held ([QMK docs](https://docs.qmk.fm/mod_tap)).
+Keys <kbd>LSft_T(<i>kc</i>)</kbd>, <kbd>LCtl_T(<i>kc</i>)</kbd>, etc. are mod-tap keys, named like the Modifier keys but with a "`_T`" suffix. These keys produce `kc` when tapped and act as a modifier when held ([QMK docs](https://docs.qmk.fm/mod_tap)).
 
 Like Modifier keys, the "`kc`" key is limited to keys in the Basic tab. This is [a QMK limitation](https://docs.qmk.fm/mod_tap#caveats). Some mod combinations are not exposed in the GUI, but can be assigned through [Any key]({% link manual/any-key.md %}) entry like "`MT(MOD_RALT | MOD_RSFT, KC_A)`."
 
@@ -72,7 +72,7 @@ Home row mods (HRMs) is an approach where the modifiers (Ctrl, Shift, Alt, GUI) 
 
 A suggested starting point for home row mods in Vial:
 
-* Use the `LCtl_T`, `LSft_T`, etc. mod-tap keys for your home row keys. Don't use Tap Dances for that.
+* Use the <kbd>LCtl_T(<i>kc</i>)</kbd>, <kbd>LSft_T(<i>kc</i>)</kbd>, etc. mod-tap keys for your home row keys. Don't use Tap Dances for that.
 
 * Under the Tap-Hold tab in QMK Settings, check the boxes for **Permissive Hold** and **Chordal Hold**, and ensure that **Hold On Other Key Press** is *unchecked*. 
 
@@ -83,16 +83,16 @@ A suggested starting point for home row mods in Vial:
 
 ## OSM mod
 
-The `OSM mod` keys are one-shot modifiers, aka sticky keys. One-shot modifiers remain active until the next key is pressed, and are then released ([QMK docs](https://docs.qmk.fm/one_shot_keys)).
+The <kbd>OSM <i>mod</i></kbd> keys are one-shot modifiers, aka sticky keys. One-shot modifiers remain active until the next key is pressed, and are then released ([QMK docs](https://docs.qmk.fm/one_shot_keys)).
 
 Some mod combinations are not exposed in the GUI, but can be assigned through [Any key]({% link manual/any-key.md %}) entry with syntax like "`OSM(MOD_RALT | MOD_RSFT)`" for one-shot Right Alt + Right Shift.
 
 
 ## Repeat Key
 
-The `Repeat` key remembers the mods that were active with the last key press. These mods are applied together with any additional mods held when `Repeat` is pressed. If Ctrl + Right Arrow was the last key pressed, then Shift + `Repeat` produces Ctrl + Shift + Right Arrow, useful to select by word.
+The <kbd>Repeat</kbd> key remembers the mods that were active with the last key press. These mods are applied together with any additional mods held when `Repeat` is pressed. If Ctrl + Right Arrow was the last key pressed, then Shift + `Repeat` produces Ctrl + Shift + Right Arrow, useful to select by word.
 
-`Alt Repeat`, by default, sends the opposing key when the last key
+<kbd>Alt Repeat</kbd>, by default, sends the opposing key when the last key
 was a navigation key. For instance when `PgDn` was the last key, `Alt Repeat` behaves as `PgUp`, and vice versa. Further examples (see [QMK docs](https://docs.qmk.fm/features/repeat_key) for full list):
 
 * `Home` &harr; `End`
@@ -114,26 +114,26 @@ Alt Repeat's behavior is configurable in the [Alt Repeat Key tab](alt-repeat-key
 
 Space Cadet keys work similarly to mod-tap keys, behaving differently when tapped vs. held ([QMK docs](https://docs.qmk.fm/features/space_cadet)):
 
-* `LS (` is Left Shift when held, `(` when tapped.
-* `RS )` is Right Shift when held, `)` when tapped.
-* `LC (` is Left Ctrl when held, `(` when tapped.
-* `RC )` is Right Ctrl when held, `)` when tapped.
-* `LA (` is Left Alt when held, `(` when tapped.
-* `RA )` is Right Alt when held, `)` when tapped.
-* `RS Enter` is Right Shift when held, Enter when tapped.
+* <kbd>LS (</kbd> is Left Shift when held, `(` when tapped.
+* <kbd>RS )</kbd> is Right Shift when held, `)` when tapped.
+* <kbd>LC (</kbd> is Left Ctrl when held, `(` when tapped.
+* <kbd>RC )</kbd> is Right Ctrl when held, `)` when tapped.
+* <kbd>LA (</kbd> is Left Alt when held, `(` when tapped.
+* <kbd>RA )</kbd> is Right Alt when held, `)` when tapped.
+* <kbd>RS Enter</kbd> is Right Shift when held, Enter when tapped.
 
 
 ## Other keys
 
-* `Bootloader`: Puts the keyboard into bootloader mode for flashing (`QK_BOOT`).
+* <kbd>Bootloader</kbd>: Puts the keyboard into bootloader mode for flashing (`QK_BOOT`).
 
-* `Reboot`: Resets the keyboard without going into bootloader mode.
+* <kbd>Reboot</kbd>: Resets the keyboard without going into bootloader mode.
 
-* `Clear EEPROM`: Clears persistent settings in the keyboard's EEPROM memory.
+* <kbd>Clear EEPROM</kbd>: Clears persistent settings in the keyboard's EEPROM memory.
 
-* `~ Esc`: Grave Escape, a key that sends Escape when pressed by itself or `~` when pressed with Shift ([QMK docs](https://docs.qmk.fm/features/grave_esc)).
+* <kbd>~ Esc</kbd>: Grave Escape, a key that sends Escape when pressed by itself or `~` when pressed with Shift ([QMK docs](https://docs.qmk.fm/features/grave_esc)).
 
-* `Swap Ctrl Caps`, etc.: "Magic Keys" functionality for dynamically swapping or disabling certain keys and toggling N-key rollover (NKRO) ([QMK docs](https://docs.qmk.fm/keycodes_magic)).
+* <kbd>Swap Ctrl Caps</kbd>, etc.: "Magic Keys" functionality for dynamically swapping or disabling certain keys and toggling N-key rollover (NKRO) ([QMK docs](https://docs.qmk.fm/keycodes_magic)).
 
 * Haptic feedback keys ([QMK docs](https://docs.qmk.fm/features/haptic_feedback)).
 


### PR DESCRIPTION
Adds scss definition for the `<kbd>` element, and uses that show Vial keys like <kbd>LCtrl_T(kc)</kbd> with distinct styling. Also added language to code blocks where missing. 

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*).