### PR TITLE
qmk_settings.md: Add per-tab specific link to QMK documentation.

### DIFF
--- a/docs/manual/qmk-settings.md
+++ b/docs/manual/qmk-settings.md
@@ -7,4 +7,15 @@ nav_order: 6
 
 # QMK Settings
 
-The QMK Settings tab can be used to configure the fine details of how QMK operates. Since Vial is built on top of QMK, reference the [QMK Documentation](https://docs.qmk.fm/) on specific features and functions.
+The QMK Settings tab can be used to configure the fine details of how QMK operates. Since Vial is built on top of QMK, users are referred to the [QMK Documentation](https://docs.qmk.fm/) for details.
+
+The QMK Settings tab includes select options from:
+
+* Magic Key ([QMK docs](https://docs.qmk.fm/keycodes_magic)).
+* Grave Escape ([QMK docs](https://docs.qmk.fm/features/grave_esc)).
+* Tap-hold configuration ([QMK docs](https://docs.qmk.fm/tap_hold)).
+* Auto Shift ([QMK docs](https://docs.qmk.fm/features/auto_shift)).
+* Combos ([QMK docs](https://docs.qmk.fm/features/combo)).
+* One Shot Keys ([QMK docs](https://docs.qmk.fm/one_shot_keys)).
+* Mouse Keys ([QMK docs](https://docs.qmk.fm/features/mouse_keys)).
+


### PR DESCRIPTION
Adds a list of links, one per each QMK Settings subtab, to the QMK documentation related to those options. E.g. https://docs.qmk.fm/tap_hold for the tap-hold configuration tab.

This PR is split off from https://github.com/vial-kb/vial-kb.github.io/pull/73 (*"Site-wide enhancements: new manuals, accessibility improvements, editing polish"*).